### PR TITLE
WebSocketClientConnection should explicitly handle failure to connect

### DIFF
--- a/src/main/scala/spray/can/websocket/WebSocketClientConnection.scala
+++ b/src/main/scala/spray/can/websocket/WebSocketClientConnection.scala
@@ -6,6 +6,7 @@ import spray.can.server.UHttp
 import spray.can.websocket
 import spray.http.HttpRequest
 import spray.http.HttpResponse
+import spray.can.Http.Connect
 
 trait WebSocketClientConnection extends Actor with ActorLogging with Stash {
   def upgradeRequest: HttpRequest
@@ -44,6 +45,10 @@ trait WebSocketClientConnection extends Actor with ActorLogging with Stash {
       _connection = sender()
       context.become(businessLogic orElse closeLogic)
       unstashAll()
+
+    case Http.CommandFailed(con: Connect) =>
+      log.warning("failed to connect to {}", con.remoteAddress)
+      context.stop(self)
 
     case cmd @ (_: Send | _: SendStream) =>
       log.debug("stashing cmd {} ", cmd)


### PR DESCRIPTION
In the case where the WebSocketClientConnection.scala fails to connect the actor is left in limbo and the consumer is left unaware. 

Suggesting the actor stops self, since it's consistent with the closeLogic and the consumer can decide to reconnect or abandon. 
