### PR TITLE
Changes for publishing to Sonatype OSS / Central

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,8 +22,15 @@ object Build extends sbt.Build {
       resolvers ++= Seq(
         "typesafe repo" at "http://repo.typesafe.com/typesafe/releases/",
         "spray" at "http://repo.spray.io",
-        "spray nightly" at "http://nightlies.spray.io/"))
-    
+        "spray nightly" at "http://nightlies.spray.io/"),
+      publishTo := {
+        val nexus = "https://oss.sonatype.org/"
+        if (version.value.trim.endsWith("SNAPSHOT"))
+          Some("snapshots" at nexus + "content/repositories/snapshots")
+        else
+          Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+      },
+      credentials += Credentials(Path.userHome / ".ivy2" / ".wandou-credentials"))
 
   lazy val formatSettings = SbtScalariform.scalariformSettings ++ Seq(
     ScalariformKeys.preferences in Compile := formattingPreferences,


### PR DESCRIPTION
Greetings, thanks for the quick merge of my previous pull request.  This pull request allows for all the com.wandoulabs projects to be pushed to Sonatype OSS, which in turn replicates to Maven Central and becomes accessible to SBT.  Please see https://issues.sonatype.org/browse/OSSRH-9455:
- Deploy snapshot artifacts into repository https://oss.sonatype.org/content/repositories/snapshots
- Deploy release artifacts into the staging repository https://oss.sonatype.org/service/local/staging/deploy/maven2
- Promote staged artifacts into repository 'Releases'
- Download snapshot and release artifacts from group https://oss.sonatype.org/content/groups/public
- Download snapshot, release and staged artifacts from staging group https://oss.sonatype.org/content/groups/staging

To use this, first add a request on the ticket for commit rights.  Then, create a set of credentials in a file named ~/.ivy2/.wandou-credentials.  The credentials are simple properties that look like this:

realm=Sonatype Nexus Repository Manager
host=oss.sonatype.org
user=topping
password=**********

Once you create these credentials, the changes in this pull request will allow you to 'sbt publish'. If the version ends in -SNAPSHOT, the artifacts will be pushed to the snapshot repository.  If not, the artifacts will be considered to be a release and a release staging area will be created.  

Thanks!  Looking forward to your work showing up in Central!
