### PR TITLE
Remove warning from incorrectly formatted debug message. 

### DIFF
--- a/spray-websocket/src/main/scala/spray/can/websocket/WebSocketFrontend.scala
+++ b/spray-websocket/src/main/scala/spray/can/websocket/WebSocketFrontend.scala
@@ -72,7 +72,7 @@ object WebSocketFrontend {
 
         case ev: Tcp.ConnectionClosed =>
           commandPL(Pipeline.Tell(handler, ev, receiverRef))
-          context.log.info("", ev) // TODO log.debug
+          context.log.debug("Connection closed" + ev)
           eventPL(ev)
 
         case ev @ Tcp.CommandFailed(e: Tcp.Write) =>


### PR DESCRIPTION
This log message is incorrectly formatted, it should be context.log.info(ev.toString) if the intent is to display an empty log message for closed connections.  But I agree with the comment that it shouldn't be making noise at info level, changed that too :)
