### PR TITLE
Fix deprecations for readLine in examples

### DIFF
--- a/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleClient.scala
+++ b/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleClient.scala
@@ -98,7 +98,7 @@ object SimpleClient extends App with MySslConfiguration {
       }))
   }
 
-  readLine("Hit ENTER to exit ...\n")
+  scala.io.StdIn.readLine("Hit ENTER to exit ...\n")
   system.shutdown()
   system.awaitTermination()
 }

--- a/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleServer.scala
+++ b/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleServer.scala
@@ -62,7 +62,7 @@ object SimpleServer extends App with MySslConfiguration {
 
     IO(UHttp) ! Http.Bind(server, "localhost", 8080)
 
-    readLine("Hit ENTER to exit ...\n")
+    scala.io.StdIn.readLine("Hit ENTER to exit ...\n")
     system.shutdown()
     system.awaitTermination()
   }


### PR DESCRIPTION
* warning was:

method readLine in trait DeprecatedPredef is deprecated:
Use the method in `scala.io.StdIn`