### PR TITLE
Backpressure in clients

### DIFF
--- a/spray-websocket/src/main/scala/spray/can/websocket/frame/Frame.scala
+++ b/spray-websocket/src/main/scala/spray/can/websocket/frame/Frame.scala
@@ -179,7 +179,9 @@ object TextFrame {
   def unapply(x: TextFrame): Option[ByteString] = Some(x.payload)
 }
 
-final class TextFrame(_finRsvOp: Byte, _payload: ByteString) extends Frame(_finRsvOp, _payload)
+final class TextFrame(_finRsvOp: Byte, _payload: ByteString) extends Frame(_finRsvOp, _payload) {
+  override def toString = _payload.utf8String.take(100)
+}
 
 object TextFrameStream {
   def apply(payload: InputStream): TextFrameStream = TextFrameStream(payload)


### PR DESCRIPTION
Servers can use `Tcp.Write` for backpressure but clients cannot. This allows savvy clients to have backpressure and also make the connection actor be more forgiving with what it accepts.
